### PR TITLE
fix akka version to overcome file size limit

### DIFF
--- a/c4gate-akka/build.sbt
+++ b/c4gate-akka/build.sbt
@@ -1,7 +1,8 @@
+resolvers += "Central Maven" at "https://search.maven.org"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.25"
 
-libraryDependencies += "com.typesafe.akka" %% "akka-http-core" % "10.1.9"
+libraryDependencies += "com.typesafe.akka" % "akka-http-core_2.12" % "10.0.13"
 
 description := s"C4 framework / http gate server to kafka"
 

--- a/c4gate-akka/build.sbt
+++ b/c4gate-akka/build.sbt
@@ -2,7 +2,7 @@
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.25"
 
 // https://mvnrepository.com/artifact/com.typesafe.akka/akka-http-core
-libraryDependencies += "com.typesafe.akka" %% "akka-http-core" % "10.1.10"
+libraryDependencies += "com.typesafe.akka" %% "akka-http-core" % "10.0.13"
 
 
 description := s"C4 framework / http gate server to kafka"

--- a/c4gate-akka/build.sbt
+++ b/c4gate-akka/build.sbt
@@ -1,7 +1,9 @@
 
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.25"
 
-libraryDependencies += "com.typesafe.akka" % "akka-http-core" % "10.1.10"
+// https://mvnrepository.com/artifact/com.typesafe.akka/akka-http-core
+libraryDependencies += "com.typesafe.akka" %% "akka-http-core" % "10.1.10"
+
 
 description := s"C4 framework / http gate server to kafka"
 

--- a/c4gate-akka/build.sbt
+++ b/c4gate-akka/build.sbt
@@ -1,7 +1,7 @@
 
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.25"
 
-libraryDependencies += "com.typesafe.akka" % "akka-http-core_2.12" % "10.0.13"
+libraryDependencies += "com.typesafe.akka" % "akka-http-core" % "10.1.10"
 
 description := s"C4 framework / http gate server to kafka"
 

--- a/c4gate-akka/build.sbt
+++ b/c4gate-akka/build.sbt
@@ -1,4 +1,3 @@
-resolvers += "Central Maven" at "https://search.maven.org"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.25"
 

--- a/c4gate-akka/src/main/resources/application.conf
+++ b/c4gate-akka/src/main/resources/application.conf
@@ -1,0 +1,2 @@
+akka.http.server.parsing.max-content-length = infinite
+akka.http.server.request-timeout = 80 s

--- a/c4gate-akka/src/main/scala/ee/cone/c4gate/AkkaImpl.scala
+++ b/c4gate-akka/src/main/scala/ee/cone/c4gate/AkkaImpl.scala
@@ -4,10 +4,9 @@ package ee.cone.c4gate
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpEntity, HttpRequest, HttpResponse}
-import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.{ActorMaterializer, Materializer, OverflowStrategy}
+import akka.http.scaladsl.model._
 import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.{ActorMaterializer, Materializer, OverflowStrategy}
 import com.typesafe.scalalogging.LazyLogging
 import ee.cone.c4actor.{Executable, Execution, Observer}
 import ee.cone.c4assemble.Single
@@ -60,10 +59,6 @@ class AkkaHttpServer(
         handler = handler,
         interface = "localhost",
         port = port,
-        settings = ServerSettings(
-          """akka.http.server.request-timeout = 80 s
-            |akka.http.server.parsing.max-content-length = infinite
-            |""".stripMargin)
         //defapply(configOverrides: String): ServerSettings(system)//ServerSettings(system)
       )(mat)
     } yield binding

--- a/c4gate-akka/src/main/scala/ee/cone/c4gate/AkkaImpl.scala
+++ b/c4gate-akka/src/main/scala/ee/cone/c4gate/AkkaImpl.scala
@@ -61,7 +61,7 @@ class AkkaHttpServer(
         interface = "localhost",
         port = port,
         settings = ServerSettings(
-          """akka.http.server.request-timeout = 60 s
+          """akka.http.server.request-timeout = 80 s
             |akka.http.server.parsing.max-content-length = infinite
             |""".stripMargin)
         //defapply(configOverrides: String): ServerSettings(system)//ServerSettings(system)


### PR DESCRIPTION
## Description
- rollback to 10.0.* akka-http version
- configuration with max-content-length didn't work in 10.1.*
- added configuration to startup
- added ignorance of body limit