### PR TITLE
#DE-23856 preserve x-r-pass-* response headers through gate inner-red…

### DIFF
--- a/base_lib/src/main/scala/ee/cone/c4gate/InternetProtocol.scala
+++ b/base_lib/src/main/scala/ee/cone/c4gate/InternetProtocol.scala
@@ -54,6 +54,13 @@ import ee.cone.c4proto._
   )
 }
 
+object HttpHeaders {
+  // Prefix marking response headers the gate must deliver to the client even through an
+  // inner-redirect (x-r-redirect-inner): the gate strips it and applies the header to the
+  // proxied response. See DefaultAkkaRequestHandler.
+  val PassPrefix = "x-r-pass-"
+}
+
 @protocol("TcpProtocolApp") object TcpProtocol   {
   @Id(0x0026) case class S_TcpWrite(
     @Id(0x002A) srcId: String,

--- a/base_server/src/main/scala/ee/cone/c4gate_akka/AkkaImpl.scala
+++ b/base_server/src/main/scala/ee/cone/c4gate_akka/AkkaImpl.scala
@@ -13,6 +13,7 @@ import com.typesafe.config.ConfigFactory
 import ee.cone.c4actor.{Config, Early, Executable, Execution, Observer}
 import ee.cone.c4assemble.Single
 import ee.cone.c4di.c4
+import ee.cone.c4gate.HttpHeaders.PassPrefix
 import ee.cone.c4gate.HttpProtocol.N_Header
 import ee.cone.c4gate_server._
 import ee.cone.c4proto.ToByteString
@@ -103,6 +104,20 @@ import scala.util.control.NonFatal
             else HttpRequest(uri = uri)
           http.singleRequest(nReq)
           //}
+        }.map { out =>
+          // PassPrefix-marked headers must reach the client even through the inner-redirect above
+          // (which otherwise returns only upstream headers): strip the prefix and graft them onto
+          // the final response, overriding same-named headers. They live on `response`, not `out`
+          // (the proxied upstream has none).
+          val passed = response.headers.collect {
+            case h if h.name.toLowerCase.startsWith(PassPrefix) => RawHeader(h.name.drop(PassPrefix.length), h.value)
+          }
+          if (passed.isEmpty) out
+          else {
+            val passedNames = passed.map(_.name.toLowerCase).toSet
+            out.withHeaders(out.headers.filterNot(h =>
+              h.name.toLowerCase.startsWith(PassPrefix) || passedNames(h.name.toLowerCase)) ++ passed)
+          }
         }
       }
     } yield response


### PR DESCRIPTION
…irect